### PR TITLE
Add Overcast Network repo and update SportBukkit version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,15 +12,15 @@
     </scm>
     <repositories>
         <repository>
-            <id>bukkit-repo</id>
-            <url>http://repo.bukkit.org/content/groups/public</url>
+            <id>overcast-network-repo</id>
+            <url>http://repo.oc.tc/content/groups/public</url>
         </repository>
     </repositories>
     <dependencies>
         <dependency>
             <groupId>tc.oc</groupId>
             <artifactId>sportbukkit-api</artifactId>
-            <version>1.5.1-R0.3-SNAPSHOT</version>
+            <version>1.5.2-R0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
SportBukkit version update is required in order for it to compile with new BlockDispenseEntityEvent.
