### PR TITLE
Fixed the weapon to be of the assailant, not the victim.

### DIFF
--- a/src/main/java/tc/oc/tracker/damage/resolvers/MeleeDamageResolver.java
+++ b/src/main/java/tc/oc/tracker/damage/resolvers/MeleeDamageResolver.java
@@ -24,7 +24,7 @@ public class MeleeDamageResolver implements DamageResolver {
                 LivingEntity attacker = (LivingEntity) entityEvent.getDamager();
 
                 Material weaponMaterial;
-                ItemStack held = entity.getEquipment().getItemInHand();
+                ItemStack held = attacker.getEquipment().getItemInHand();
                 if(held != null) {
                     weaponMaterial = held.getType();
                 } else {


### PR DESCRIPTION
I noticed when using `.getWeapon()` on an instance of `MeleeDamageInfo`, the returned weapon material was the item that the victim was holding, not the assailant. As per this comment in `MeleeDamageInfo.java`;

``` java
/**
 * Gets the material of the weapon that the assailant used.
 *
 * Note: fist kills will return {@link Material.AIR}.
 *
 * @return Material of weapon used
 */
@Nonnull Material getWeapon();
```

I determined that this was a possible bug and made the change.
