### PR TITLE
Add potion resolving

### DIFF
--- a/src/main/java/tc/oc/tracker/damage/PotionDamageInfo.java
+++ b/src/main/java/tc/oc/tracker/damage/PotionDamageInfo.java
@@ -1,0 +1,31 @@
+package tc.oc.tracker.damage;
+
+
+import org.bukkit.potion.PotionEffectType;
+import tc.oc.tracker.DamageInfo;
+
+/**
+ * Represents the damage caused by potions
+ */
+public interface PotionDamageInfo extends DamageInfo {
+    /**
+     * Returns the PotionEffectType of the PotionEffect
+     *
+     * @return type of potion effect
+     */
+    PotionEffectType getType();
+
+    /**
+     * Returns the amplifier of the potion effect
+     *
+     * @return potion effect amplifier
+     */
+    int getAmplifier();
+
+    /**
+     * Returns the duration of the potion effect
+     *
+     * @return duration of the potion effect
+     */
+    int getDuration();
+}

--- a/src/main/java/tc/oc/tracker/damage/base/SimplePotionDamageInfo.java
+++ b/src/main/java/tc/oc/tracker/damage/base/SimplePotionDamageInfo.java
@@ -1,0 +1,38 @@
+package tc.oc.tracker.damage.base;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import tc.oc.tracker.base.AbstractDamageInfo;
+import tc.oc.tracker.damage.PotionDamageInfo;
+
+import javax.annotation.Nullable;
+
+public class SimplePotionDamageInfo extends AbstractDamageInfo implements PotionDamageInfo {
+    public SimplePotionDamageInfo(@Nullable LivingEntity resolvedDamager, PotionEffect potionEffect) {
+        super(resolvedDamager);
+
+        Preconditions.checkNotNull(potionEffect, "potion effect can not be null");
+
+        this.potionEffectType = potionEffect.getType();
+        this.amplifier = potionEffect.getAmplifier();
+        this.duration = potionEffect.getDuration();
+    }
+
+    public PotionEffectType getType() {
+        return this.potionEffectType;
+    }
+
+    public int getAmplifier() {
+        return this.amplifier;
+    }
+
+    public int getDuration() {
+        return this.duration;
+    }
+
+    private PotionEffectType potionEffectType;
+    private int amplifier;
+    private int duration;
+}

--- a/src/main/java/tc/oc/tracker/damage/resolvers/PotionDamageResolver.java
+++ b/src/main/java/tc/oc/tracker/damage/resolvers/PotionDamageResolver.java
@@ -1,0 +1,59 @@
+package tc.oc.tracker.damage.resolvers;
+
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.ThrownPotion;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import tc.oc.tracker.DamageInfo;
+import tc.oc.tracker.DamageResolver;
+import tc.oc.tracker.Lifetime;
+import tc.oc.tracker.damage.base.SimplePotionDamageInfo;
+
+import javax.annotation.Nonnull;
+
+public class PotionDamageResolver implements DamageResolver {
+    public DamageInfo resolve(@Nonnull LivingEntity entity, @Nonnull Lifetime lifetime, @Nonnull EntityDamageEvent damageEvent) {
+        if (!(damageEvent.getEntity() instanceof Player)) return null;
+        if (damageEvent.getCause() == EntityDamageEvent.DamageCause.WITHER || damageEvent.getCause() == EntityDamageEvent.DamageCause.POISON) {
+            Player player = (Player) damageEvent.getEntity();
+
+            if (damageEvent.getCause() == EntityDamageEvent.DamageCause.POISON) {
+                return new SimplePotionDamageInfo(null, getPotionEffect(player, PotionEffectType.POISON));
+            } else if (damageEvent.getCause() == EntityDamageEvent.DamageCause.WITHER) {
+                return new SimplePotionDamageInfo(null, getPotionEffect(player, PotionEffectType.WITHER));
+            }
+        }
+        if (damageEvent instanceof EntityDamageByEntityEvent) {
+            EntityDamageByEntityEvent sub = (EntityDamageByEntityEvent) damageEvent;
+            if (sub.getDamager() instanceof ThrownPotion) {
+                ThrownPotion thrownPotion = (ThrownPotion) sub.getDamager();
+                PotionEffect potionEffect = null;
+                for (PotionEffect pe : thrownPotion.getEffects()) {
+                    if (pe.getType().equals(PotionEffectType.HARM)) {
+                        potionEffect = pe;
+                        break;
+                    }
+                }
+                if (potionEffect != null) {
+                    if (thrownPotion.getShooter() != null) {
+                        return new SimplePotionDamageInfo(thrownPotion.getShooter(), potionEffect);
+                    }
+                    return new SimplePotionDamageInfo(null, potionEffect);
+                }
+            }
+        }
+        return null;
+    }
+
+    private PotionEffect getPotionEffect(Player player, PotionEffectType potionEffectType) {
+        for (PotionEffect potionEffect : player.getActivePotionEffects()) {
+            if (potionEffect.getType().equals(potionEffectType)) {
+                return potionEffect;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/tc/oc/tracker/plugin/TrackerPlugin.java
+++ b/src/main/java/tc/oc/tracker/plugin/TrackerPlugin.java
@@ -9,17 +9,7 @@ import tc.oc.tracker.DamageResolverManager;
 import tc.oc.tracker.DamageResolvers;
 import tc.oc.tracker.TrackerManager;
 import tc.oc.tracker.Trackers;
-import tc.oc.tracker.damage.resolvers.AnvilDamageResolver;
-import tc.oc.tracker.damage.resolvers.BlockDamageResolver;
-import tc.oc.tracker.damage.resolvers.DispensedProjectileDamageResolver;
-import tc.oc.tracker.damage.resolvers.FallDamageResolver;
-import tc.oc.tracker.damage.resolvers.GravityDamageResolver;
-import tc.oc.tracker.damage.resolvers.LavaDamageResolver;
-import tc.oc.tracker.damage.resolvers.MeleeDamageResolver;
-import tc.oc.tracker.damage.resolvers.OwnedMobDamageResolver;
-import tc.oc.tracker.damage.resolvers.ProjectileDamageResolver;
-import tc.oc.tracker.damage.resolvers.TNTDamageResolver;
-import tc.oc.tracker.damage.resolvers.VoidDamageResolver;
+import tc.oc.tracker.damage.resolvers.*;
 import tc.oc.tracker.timer.TickTimer;
 import tc.oc.tracker.trackers.AnvilTracker;
 import tc.oc.tracker.trackers.DispenserTracker;
@@ -107,6 +97,7 @@ public class TrackerPlugin extends JavaPlugin {
         drm.register(new DispensedProjectileDamageResolver(projectileDistanceTracker, dispenserTracker));
         drm.register(new OwnedMobDamageResolver(ownedMobTracker));
         drm.register(new AnvilDamageResolver(anvilTracker));
+        drm.register(new PotionDamageResolver());
 
         // debug
         // this.registerEvents(new DebugListener());


### PR DESCRIPTION
Adds functionality for #2. This only resolves Harm, poison, and wither potions, which either do damage over time, or are a one time potion. Harm potions are tracked through thrown potions, since it appears that they are never added to the player's active potion effects, while poison and wither potions are, and are tracked through EntityDamageEvent. If it's an instanceof a damage potion then the shooter will be the entity that threw the potion, otherwise the damager is null. If you want to track the actual damager over time for poison and wither potions, let me know.
